### PR TITLE
fix: ensure union tag_values are compared as string

### DIFF
--- a/lib/ash/type/union.ex
+++ b/lib/ash/type/union.ex
@@ -230,7 +230,7 @@ defmodule Ash.Type.Union do
             value
           end
 
-        if (Map.get(value, config[:tag]) || Map.get(value, to_string(config[:tag]))) == tag_value do
+        if Map.get(value, config[:tag]) || Map.get(value, to_string(config[:tag])) == to_string(tag_value) do
           case Ash.Type.cast_input(type, value, config[:constraints] || []) do
             {:ok, value} ->
               case Ash.Type.apply_constraints(type, value, config[:constraints]) do


### PR DESCRIPTION
We casting the union input, ensure the tag value is a string.

# Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
